### PR TITLE
Add support for Bcrypt password hashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,6 @@
 			<version>1.1.3</version>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
@@ -297,14 +296,20 @@
 			<version>20.0</version>
 		</dependency>
 
-
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-sts</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-crypto</artifactId>
+			<version>5.2.1.RELEASE</version>
 		</dependency>
 
 		<!-- Test Dependencies -->

--- a/src/main/java/cloudgene/mapred/util/HashUtil.java
+++ b/src/main/java/cloudgene/mapred/util/HashUtil.java
@@ -1,23 +1,33 @@
 package cloudgene.mapred.util;
 
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class HashUtil {
 
-	public static String getMD5(String pwd) {
-		MessageDigest m = null;
-		String result = "";
-		try {
-			m = MessageDigest.getInstance("MD5");
-		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
-		}
-		m.update(pwd.getBytes(), 0, pwd.length());
-		result = new BigInteger(1, m.digest()).toString(16);
-		return result;
-	}
+    public static String getMD5(String pwd) {
+        MessageDigest m = null;
+        String result = "";
+        try {
+            m = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        m.update(pwd.getBytes(), 0, pwd.length());
+        result = new BigInteger(1, m.digest()).toString(16);
+        return result;
+    }
 
-	
+    /** Return BCrypt hash from input */
+    public static String getBCrypt(String input) {
+        return BCrypt.hashpw(input, BCrypt.gensalt());
+    }
+
+    /** Check if a provided candidate password is the same as an existing hash */
+    public static boolean checkBCrypt(String candidate, String hash) {
+        return BCrypt.checkpw(candidate, hash);
+    }
 }

--- a/src/test/java/cloudgene/mapred/util/TestHashUtil.java
+++ b/src/test/java/cloudgene/mapred/util/TestHashUtil.java
@@ -1,0 +1,25 @@
+package cloudgene.mapred.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestHashUtil {
+
+    @Test
+    public void testBCryptHash() {
+        String password = "P@assW0rd!Test";
+        String passwordHash = HashUtil.getBCrypt(password);
+        assertTrue("Candidate password should match stored hash:",
+                HashUtil.checkBCrypt(password, passwordHash));
+    }
+
+    @Test
+    public void testMD5Hash() {
+        String password = "P@assW0rd!Test";
+        String passwordHash = HashUtil.getMD5(password);
+        assertEquals("Generated MD5 hash should match",
+                "801f65f0fb7f4417b2e2cc5490c88cc3", passwordHash);
+    }
+}


### PR DESCRIPTION
MD5 is considered a legacy algorithm for password hashing and should not be used to store user passwords. Bcrypt provides a modern attack-resistant hashing algorithm specifically designed for securely storing passwords. This PR adds methods for creating and checking Bcrypt hashes, however does not implement these methods into user login and password creation logic.

Summary of changes:
- Add bcrypt methods in HashUtil class
- Add dependencies to maven
- Add test coverage for HashUtil class methods new and old

[OWASP Password Storage Cheat Sheet](https://owasp.org/www-project-cheat-sheets/cheatsheets/Password_Storage_Cheat_Sheet.html)