### PR TITLE
[v3.x] Switch to sl4j and add logging of API endpoint usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,16 +169,6 @@
 			<version>2.5.1</version>
 		</dependency>
 
-		<!-- Logging -->
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.28</version>
-		</dependency>
-
-		<!-- End Logging -->
-
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
@@ -262,6 +252,10 @@
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpcore</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -271,6 +265,12 @@
 			<version>${hadoop.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+			</exclusions>			
 		</dependency>
 
 		<dependency>

--- a/src/main/java/cloudgene/mapred/apps/ApplicationRepository.java
+++ b/src/main/java/cloudgene/mapred/apps/ApplicationRepository.java
@@ -11,8 +11,8 @@ import java.util.Map;
 import java.util.Vector;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -37,7 +37,7 @@ public class ApplicationRepository {
 
 	private String appsFolder = "apps";
 
-	private static final Log log = LogFactory.getLog(ApplicationRepository.class);
+	private static final Logger log = LoggerFactory.getLogger(ApplicationRepository.class);
 
 	public static int APPS = 1;
 

--- a/src/main/java/cloudgene/mapred/core/User.java
+++ b/src/main/java/cloudgene/mapred/core/User.java
@@ -30,6 +30,8 @@ public class User {
 	private int loginAttempts;
 
 	private Date apiTokenExpiresOn = null;
+	
+	private boolean accessedByApi = false;
 
 	public static final String ROLE_SEPARATOR = ",";
 
@@ -178,6 +180,14 @@ public class User {
 
 		return null;
 
+	}
+	
+	public void setAccessedByApi(boolean accessedByApi) {
+		this.accessedByApi = accessedByApi;
+	}
+	
+	public boolean isAccessedByApi() {
+		return accessedByApi;
 	}
 
 	public static String checkPassword(String password, String confirmPassword) {

--- a/src/main/java/cloudgene/mapred/database/CounterDao.java
+++ b/src/main/java/cloudgene/mapred/database/CounterDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.AbstractJob;
 import genepi.db.Database;
@@ -15,7 +15,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class CounterDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(CounterDao.class);
+	private static final Logger log = LoggerFactory.getLogger(CounterDao.class);
 
 	public CounterDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/CounterHistoryDao.java
+++ b/src/main/java/cloudgene/mapred/database/CounterHistoryDao.java
@@ -11,15 +11,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import genepi.db.Database;
 import genepi.db.JdbcDataAccessObject;
 
 public class CounterHistoryDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(CounterHistoryDao.class);
+	private static final Logger log = LoggerFactory.getLogger(CounterHistoryDao.class);
 
 	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(
 			"yy-MM-dd HH:mm");

--- a/src/main/java/cloudgene/mapred/database/DownloadDao.java
+++ b/src/main/java/cloudgene/mapred/database/DownloadDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.CloudgeneParameterOutput;
 import cloudgene.mapred.jobs.Download;
@@ -16,7 +16,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class DownloadDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(DownloadDao.class);
+	private static final Logger log = LoggerFactory.getLogger(DownloadDao.class);
 
 	public DownloadDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/JobDao.java
+++ b/src/main/java/cloudgene/mapred/database/JobDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.database.UserDao.UserMapper;
@@ -21,7 +21,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class JobDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(JobDao.class);
+	private static final Logger log = LoggerFactory.getLogger(JobDao.class);
 
 	public JobDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/MessageDao.java
+++ b/src/main/java/cloudgene/mapred/database/MessageDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.CloudgeneStep;
 import cloudgene.mapred.jobs.Message;
@@ -16,7 +16,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class MessageDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(MessageDao.class);
+	private static final Logger log = LoggerFactory.getLogger(MessageDao.class);
 
 	public MessageDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/ParameterDao.java
+++ b/src/main/java/cloudgene/mapred/database/ParameterDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.AbstractJob;
 import cloudgene.mapred.jobs.CloudgeneParameterInput;
@@ -20,7 +20,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class ParameterDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(ParameterDao.class);
+	private static final Logger log = LoggerFactory.getLogger(ParameterDao.class);
 
 	public ParameterDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/StepDao.java
+++ b/src/main/java/cloudgene/mapred/database/StepDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.CloudgeneJob;
 import cloudgene.mapred.jobs.CloudgeneStep;
@@ -18,7 +18,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class StepDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(StepDao.class);
+	private static final Logger log = LoggerFactory.getLogger(StepDao.class);
 
 	public StepDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/TemplateDao.java
+++ b/src/main/java/cloudgene/mapred/database/TemplateDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.Template;
 import genepi.db.Database;
@@ -15,7 +15,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class TemplateDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(TemplateDao.class);
+	private static final Logger log = LoggerFactory.getLogger(TemplateDao.class);
 
 	public TemplateDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/UserDao.java
+++ b/src/main/java/cloudgene/mapred/database/UserDao.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.util.PublicUser;
@@ -16,7 +16,7 @@ import genepi.db.JdbcDataAccessObject;
 
 public class UserDao extends JdbcDataAccessObject {
 
-	private static final Log log = LogFactory.getLog(UserDao.class);
+	private static final Logger log = LoggerFactory.getLogger(UserDao.class);
 
 	public UserDao(Database database) {
 		super(database);

--- a/src/main/java/cloudgene/mapred/database/updates/BcryptHashUpdate.java
+++ b/src/main/java/cloudgene/mapred/database/updates/BcryptHashUpdate.java
@@ -2,8 +2,8 @@ package cloudgene.mapred.database.updates;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import cloudgene.mapred.core.User;
@@ -13,7 +13,7 @@ import genepi.db.IUpdateListener;
 
 public class BcryptHashUpdate implements IUpdateListener {
 
-	private static final Log log = LogFactory.getLog(BcryptHashUpdate.class);
+	private static final Logger log = LoggerFactory.getLogger(BcryptHashUpdate.class);
 
 	
 	@Override

--- a/src/main/java/cloudgene/mapred/database/util/Fixtures.java
+++ b/src/main/java/cloudgene/mapred/database/util/Fixtures.java
@@ -1,7 +1,7 @@
 package cloudgene.mapred.database.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.Template;
 import cloudgene.mapred.core.User;
@@ -12,7 +12,7 @@ import genepi.db.Database;
 
 public class Fixtures {
 
-	private static final Log log = LogFactory.getLog(Fixtures.class);
+	private static final Logger log = LoggerFactory.getLogger(Fixtures.class);
 
 	public static String USERNAME = "admin";
 

--- a/src/main/java/cloudgene/mapred/jobs/AbstractJob.java
+++ b/src/main/java/cloudgene/mapred/jobs/AbstractJob.java
@@ -13,7 +13,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.jobs.queue.PriorityRunnable;
@@ -23,7 +24,7 @@ import genepi.io.FileUtil;
 
 abstract public class AbstractJob extends PriorityRunnable {
 
-	private static final org.apache.commons.logging.Log log = LogFactory.getLog(AbstractJob.class);
+	private static final Logger log = LoggerFactory.getLogger(AbstractJob.class);
 
 	private DateFormat formatter = new SimpleDateFormat("yy/MM/dd HH:mm:ss");
 

--- a/src/main/java/cloudgene/mapred/jobs/CloudgeneJob.java
+++ b/src/main/java/cloudgene/mapred/jobs/CloudgeneJob.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.Vector;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.apps.Application;
 import cloudgene.mapred.apps.ApplicationInstaller;
@@ -42,7 +42,7 @@ public class CloudgeneJob extends AbstractJob {
 
 	public static final int MAX_DOWNLOAD = 10;
 
-	private static final Log log = LogFactory.getLog(CloudgeneJob.class);
+	private static Logger log = LoggerFactory.getLogger(CloudgeneJob.class);
 
 	private String externalOutput = null;
 

--- a/src/main/java/cloudgene/mapred/jobs/PersistentWorkflowEngine.java
+++ b/src/main/java/cloudgene/mapred/jobs/PersistentWorkflowEngine.java
@@ -3,8 +3,8 @@ package cloudgene.mapred.jobs;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.database.CounterDao;
 import cloudgene.mapred.database.DownloadDao;
@@ -16,7 +16,7 @@ import genepi.db.Database;
 
 public class PersistentWorkflowEngine extends WorkflowEngine {
 
-	private static final Log log = LogFactory.getLog(PersistentWorkflowEngine.class);
+	private static final Logger log = LoggerFactory.getLogger(PersistentWorkflowEngine.class);
 
 	private Database database;
 
@@ -51,11 +51,13 @@ public class PersistentWorkflowEngine extends WorkflowEngine {
 
 	@Override
 	protected void statusUpdated(AbstractJob job) {
+		super.statusUpdated(job);
 		dao.update(job);
 	}
 
 	@Override
 	protected void jobCompleted(AbstractJob job) {
+		super.jobCompleted(job);
 
 		DownloadDao downloadDao = new DownloadDao(database);
 
@@ -118,6 +120,7 @@ public class PersistentWorkflowEngine extends WorkflowEngine {
 
 	@Override
 	protected void jobSubmitted(AbstractJob job) {
+		super.jobSubmitted(job);
 		dao.insert(job);
 
 		ParameterDao dao = new ParameterDao(database);

--- a/src/main/java/cloudgene/mapred/jobs/WorkflowEngine.java
+++ b/src/main/java/cloudgene/mapred/jobs/WorkflowEngine.java
@@ -5,8 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.jobs.queue.PriorityRunnable;
@@ -26,7 +26,7 @@ public class WorkflowEngine implements Runnable {
 
 	private AtomicLong priorityCounter = new AtomicLong();
 
-	private static final Log log = LogFactory.getLog(WorkflowEngine.class);
+	private static final Logger log = LoggerFactory.getLogger(WorkflowEngine.class);
 
 	public WorkflowEngine(int ltqThreads, int stqThreads) {
 

--- a/src/main/java/cloudgene/mapred/jobs/engine/graph/GraphNode.java
+++ b/src/main/java/cloudgene/mapred/jobs/engine/graph/GraphNode.java
@@ -10,8 +10,8 @@ import java.net.URLClassLoader;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.AbstractJob;
 import cloudgene.mapred.jobs.CloudgeneContext;
@@ -35,7 +35,7 @@ public class GraphNode implements Runnable {
 
 	private CloudgeneStep instance;
 
-	private static final Log log = LogFactory.getLog(CloudgeneJob.class);
+	private static final Logger log = LoggerFactory.getLogger(CloudgeneJob.class);
 
 	private boolean successful = false;
 

--- a/src/main/java/cloudgene/mapred/jobs/queue/PriorityThreadPoolExecutor.java
+++ b/src/main/java/cloudgene/mapred/jobs/queue/PriorityThreadPoolExecutor.java
@@ -6,14 +6,14 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PriorityThreadPoolExecutor {
 	private PausableThreadPoolExecutor executor;
 	private BlockingQueue<Runnable> queue;
 
-	private static final Log log = LogFactory.getLog(PriorityThreadPoolExecutor.class);
+	private static final Logger log = LoggerFactory.getLogger(PriorityThreadPoolExecutor.class);
 
 	public PriorityThreadPoolExecutor(int threads, boolean priority) {
 		if (priority) {

--- a/src/main/java/cloudgene/mapred/jobs/queue/Queue.java
+++ b/src/main/java/cloudgene/mapred/jobs/queue/Queue.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.Future;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.jobs.AbstractJob;
@@ -29,7 +29,7 @@ public abstract class Queue implements Runnable {
 
 	private boolean priority = false;
 
-	private static final Log log = LogFactory.getLog(Queue.class);
+	private static final Logger log = LoggerFactory.getLogger(Queue.class);
 
 	public Queue(String name, int threads, boolean updatePositions, boolean priority) {
 		this.name = name;

--- a/src/main/java/cloudgene/mapred/jobs/workspace/S3Workspace.java
+++ b/src/main/java/cloudgene/mapred/jobs/workspace/S3Workspace.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
@@ -24,7 +24,7 @@ public class S3Workspace implements IExternalWorkspace {
 
 	public static long EXPIRATION_MS = 1000 * 60 * 60;
 
-	private static final Log log = LogFactory.getLog(S3Workspace.class);
+	private static final Logger log = LoggerFactory.getLogger(S3Workspace.class);
 
 	private String location;
 

--- a/src/main/java/cloudgene/mapred/plugins/PluginManager.java
+++ b/src/main/java/cloudgene/mapred/plugins/PluginManager.java
@@ -5,8 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.plugins.docker.DockerPlugin;
 import cloudgene.mapred.plugins.hadoop.HadoopPlugin;
@@ -23,7 +23,7 @@ public class PluginManager {
 
 	private static PluginManager instance = null;
 
-	private static final Log log = LogFactory.getLog(PluginManager.class);
+	private static Logger log = LoggerFactory.getLogger(PluginManager.class);
 
 	public static PluginManager getInstance() {
 		if (instance == null) {

--- a/src/main/java/cloudgene/mapred/server/Application.java
+++ b/src/main/java/cloudgene/mapred/server/Application.java
@@ -6,8 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.database.TemplateDao;
 import cloudgene.mapred.database.updates.BcryptHashUpdate;
@@ -39,7 +39,7 @@ public class Application {
 
 	private Map<String, String> cacheTemplates;
 
-	protected Log log = LogFactory.getLog(Application.class);
+	protected Logger log = LoggerFactory.getLogger(Application.class);
 
 	public Application() throws Exception {
 

--- a/src/main/java/cloudgene/mapred/server/auth/DatabaseAuthenticationProvider.java
+++ b/src/main/java/cloudgene/mapred/server/auth/DatabaseAuthenticationProvider.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.Date;
 
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.database.UserDao;
@@ -20,13 +22,15 @@ import reactor.core.publisher.Mono;
 @Singleton
 public class DatabaseAuthenticationProvider implements AuthenticationProvider {
 
+	private static Logger log = LoggerFactory.getLogger(DatabaseAuthenticationProvider.class);
+	
 	private static final String MESSAGE_LOGIN_FAILED = "Login Failed! Wrong Username or Password.";
 
 	private static final String MESSAGE_ACCOUNT_IS_INACTIVE = "Login Failed! User account is not activated.";
 
 	private static final String MESSAGE_ACCOUNT_LOCKED = "The user account is locked for %d minutes. Too many failed logins.";
 
-	public static final int MAX_LOGIN_ATTEMMPTS = 5;
+	public static final int MAX_LOGIN_ATTEMPTS = 5;
 
 	public static final int LOCKING_TIME_MIN = 30;
 
@@ -48,12 +52,21 @@ public class DatabaseAuthenticationProvider implements AuthenticationProvider {
 			if (user != null) {
 
 				if (!user.isActive()) {
+
+					log.info(String.format(
+							"Authorization failure: User account is not activated for account %s (ID %s - email %s)",
+							user.getUsername(), user.getId(), user.getMail()));
+
 					emitter.error(AuthenticationResponse.exception(MESSAGE_ACCOUNT_IS_INACTIVE));
 					return;
 				}
 
-				if (user.getLoginAttempts() >= MAX_LOGIN_ATTEMMPTS) {
+				if (user.getLoginAttempts() >= MAX_LOGIN_ATTEMPTS) {
 					if (user.getLockedUntil() == null || user.getLockedUntil().after(new Date())) {
+
+						log.info(String.format(
+								"Authorization failure: login retries are currently locked for account %s (ID %s - email %s)",
+								user.getUsername(), user.getId(), user.getMail()));
 
 						emitter.error(AuthenticationResponse
 								.exception(String.format(MESSAGE_ACCOUNT_LOCKED, LOCKING_TIME_MIN)));
@@ -61,6 +74,9 @@ public class DatabaseAuthenticationProvider implements AuthenticationProvider {
 
 					} else {
 						// penalty time is over. set to zero
+						log.info(String.format(
+								"Authorization: Account login lock has expired; releasing for account %s (ID %s - email %s)",
+								user.getUsername(), user.getId(), user.getMail()));
 						user.setLoginAttempts(0);
 					}
 				}
@@ -70,6 +86,15 @@ public class DatabaseAuthenticationProvider implements AuthenticationProvider {
 					user.setLoginAttempts(0);
 					user.setLastLogin(new Date());
 					dao.update(user);
+
+					String message = String.format("Authorization success: user login %s (ID %s - email %s)",
+							user.getUsername(), user.getId(), user.getMail());
+					if (user.isAdmin()) {
+						// Note: Admin user logins are called out explicitly, to aid log analysis in the
+						// event of a breach
+						message += " (ADMIN)";
+					}
+					log.info(message);
 
 					emitter.success(AuthenticationResponse.success(user.getUsername(), Arrays.asList(user.getRoles())));
 
@@ -81,15 +106,23 @@ public class DatabaseAuthenticationProvider implements AuthenticationProvider {
 					user.setLoginAttempts(attempts);
 
 					// too many, lock user
-					if (attempts >= MAX_LOGIN_ATTEMMPTS) {
+					if (attempts >= MAX_LOGIN_ATTEMPTS) {
+
+						log.warn(String.format(
+								"Authorization failure: User account %s (ID %s - email %s) locked due to too many failed logins",
+								user.getUsername(), user.getId(), user.getMail()));
+
 						user.setLockedUntil(new Date(System.currentTimeMillis() + (LOCKING_TIME_MIN * 60 * 1000)));
 					}
 					dao.update(user);
+
+					log.warn(String.format("Authorization failure: Invalid password for username: %s", loginUsername));
 
 					emitter.error(AuthenticationResponse.exception(MESSAGE_LOGIN_FAILED));
 					return;
 				}
 			} else {
+				log.warn(String.format("Authorization failure: unknown username: %s", loginUsername));
 				emitter.error(AuthenticationResponse.exception(MESSAGE_LOGIN_FAILED));
 				return;
 			}

--- a/src/main/java/cloudgene/mapred/server/controller/ApiTokenController.java
+++ b/src/main/java/cloudgene/mapred/server/controller/ApiTokenController.java
@@ -1,5 +1,8 @@
 package cloudgene.mapred.server.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import cloudgene.mapred.core.ApiToken;
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.database.UserDao;
@@ -8,6 +11,7 @@ import cloudgene.mapred.server.auth.AuthenticationService;
 import cloudgene.mapred.server.responses.ApiTokenResponse;
 import cloudgene.mapred.server.responses.MessageResponse;
 import cloudgene.mapred.server.responses.ValidatedApiTokenResponse;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Consumes;
@@ -19,11 +23,12 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.rules.SecurityRule;
 import jakarta.inject.Inject;
-import io.micronaut.core.annotation.Nullable;
 
 @Controller
 public class ApiTokenController {
 
+	private static Logger log = LoggerFactory.getLogger(ApiTokenController.class);
+	
 	private static final String MESSAGE_API_TOKEN_CREATED = "Creation successfull.";
 
 	private static final String MESSAGE_APT_TOKEN_ERROR = "Error during API token generation.";
@@ -62,6 +67,8 @@ public class ApiTokenController {
 
 		if (successful) {
 
+			log.info(String.format("User: generated API token for user %s (ID %s - email %s)", user.getUsername(), user.getId(), user.getMail()));
+			
 			return HttpResponse.ok(new ApiTokenResponse(apiToken));
 
 		} else {
@@ -87,6 +94,8 @@ public class ApiTokenController {
 
 		if (successful) {
 
+			log.info(String.format("User: revoked API token for user %s (ID %s - email %s)", user.getUsername(), user.getId(), user.getMail()));
+			
 			return HttpResponse.ok(MessageResponse.success(MESSAGE_API_TOKEN_CREATED));
 
 		} else {

--- a/src/main/java/cloudgene/mapred/server/controller/DownloadController.java
+++ b/src/main/java/cloudgene/mapred/server/controller/DownloadController.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.database.DownloadDao;
@@ -32,7 +32,7 @@ import jakarta.inject.Inject;
 @Controller
 public class DownloadController {
 
-	protected static final Log log = LogFactory.getLog(DownloadController.class);
+	protected static final Logger log = LoggerFactory.getLogger(DownloadController.class);
 
 	@Inject
 	protected Application application;

--- a/src/main/java/cloudgene/mapred/server/controller/LogController.java
+++ b/src/main/java/cloudgene/mapred/server/controller/LogController.java
@@ -1,5 +1,8 @@
 package cloudgene.mapred.server.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.jobs.AbstractJob;
 import cloudgene.mapred.server.Application;
@@ -20,6 +23,8 @@ import jakarta.inject.Inject;
 @Controller
 public class LogController {
 
+	private static Logger log = LoggerFactory.getLogger(LogController.class);
+	
 	@Inject
 	protected Application application;
 
@@ -57,6 +62,14 @@ public class LogController {
 			buffer.append("\n\nstd.out:\n\n");
 			buffer.append(outputContent);
 		}
+		
+		
+		String message = String.format("Job: viewing logs for job ID %s", job.getId());
+		if (user.isAdmin()) {
+			message += String.format(" (by ADMIN user ID %s - email %s)", user.getId(), user.getMail());
+		}
+		log.info(message);
+		
 		return buffer.toString();
 
 	}

--- a/src/main/java/cloudgene/mapred/server/controller/NextflowController.java
+++ b/src/main/java/cloudgene/mapred/server/controller/NextflowController.java
@@ -2,8 +2,8 @@ package cloudgene.mapred.server.controller;
 
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.plugins.nextflow.NextflowInfo;
 import cloudgene.mapred.server.Application;
@@ -22,7 +22,7 @@ import net.sf.json.JSONObject;
 @Controller
 public class NextflowController {
 
-	protected static final Log log = LogFactory.getLog(DownloadController.class);
+	protected static final Logger log = LoggerFactory.getLogger(DownloadController.class);
 
 	@Inject
 	protected Application application;

--- a/src/main/java/cloudgene/mapred/server/services/ApplicationService.java
+++ b/src/main/java/cloudgene/mapred/server/services/ApplicationService.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.apps.Application;
 import cloudgene.mapred.apps.ApplicationInstaller;
@@ -33,7 +33,7 @@ public class ApplicationService {
 	private static final String NO_URL = "No url or file location set.";
 	private static final String APPLICATION_NOT_INSTALLED_NO_WORKFLOW = "Application not installed: No workflow file found.";
 
-	private static final Log log = LogFactory.getLog(ApplicationService.class);
+	private static final Logger log = LoggerFactory.getLogger(ApplicationService.class);
 
 	@Inject
 	protected cloudgene.mapred.server.Application application;

--- a/src/main/java/cloudgene/mapred/server/services/JobCleanUpService.java
+++ b/src/main/java/cloudgene/mapred/server/services/JobCleanUpService.java
@@ -203,7 +203,7 @@ public class JobCleanUpService {
 
 		}
 
-		log.info(send + " notifications sent. " + otherJobs + " jobs marked without email notfication.");
+		log.info(send + " notifications sent. " + otherJobs + " jobs marked without email notification.");
 
 		return send;
 

--- a/src/main/java/cloudgene/mapred/server/services/JobCleanUpService.java
+++ b/src/main/java/cloudgene/mapred/server/services/JobCleanUpService.java
@@ -2,8 +2,8 @@ package cloudgene.mapred.server.services;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.core.Template;
 import cloudgene.mapred.database.JobDao;
@@ -22,7 +22,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class JobCleanUpService {
 
-	private static final Log log = LogFactory.getLog(JobCleanUpService.class);
+	private static final Logger log = LoggerFactory.getLogger(JobCleanUpService.class);
 
 	@Inject
 	protected Application application;

--- a/src/main/java/cloudgene/mapred/steps/JavaExternalStep.java
+++ b/src/main/java/cloudgene/mapred/steps/JavaExternalStep.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cloudgene.mapred.jobs.CloudgeneContext;
 import cloudgene.mapred.jobs.CloudgeneStep;
@@ -15,7 +15,7 @@ import genepi.io.FileUtil;
 
 public class JavaExternalStep extends CloudgeneStep {
 
-	protected static final Log log = LogFactory.getLog(JavaExternalStep.class);
+	protected static final Logger log = LoggerFactory.getLogger(JavaExternalStep.class);
 
 	public boolean run(WdlStep step, CloudgeneContext context) {
 

--- a/src/main/java/cloudgene/mapred/util/MailUtil.java
+++ b/src/main/java/cloudgene/mapred/util/MailUtil.java
@@ -10,11 +10,12 @@ import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MailUtil {
 
-	private static final org.apache.commons.logging.Log log = LogFactory.getLog(MailUtil.class);
+	private static final Logger log = LoggerFactory.getLogger(MailUtil.class);
 
 	public static void notifyAdmin(Settings settings, String subject, String text) throws Exception {
 

--- a/src/main/java/cloudgene/mapred/util/Settings.java
+++ b/src/main/java/cloudgene/mapred/util/Settings.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlException;
@@ -76,7 +76,7 @@ public class Settings {
 
 	private boolean removeHdfsWorkspace = true;
 
-	private static final Log log = LogFactory.getLog(Settings.class);
+	private static final Logger log = LoggerFactory.getLogger(Settings.class);
 
 	private boolean writeStatistics = true;
 

--- a/src/test/java/cloudgene/mapred/api/v2/users/LoginUserTest.java
+++ b/src/test/java/cloudgene/mapred/api/v2/users/LoginUserTest.java
@@ -107,7 +107,7 @@ public class LoginUserTest {
 		int oldLoginAttempts = dao.findByUsername("lockeduser").getLoginAttempts();
 
 		// login should work xx times
-		for (int i = 1; i < DatabaseAuthenticationProvider.MAX_LOGIN_ATTEMMPTS + 10; i++) {
+		for (int i = 1; i < DatabaseAuthenticationProvider.MAX_LOGIN_ATTEMPTS + 10; i++) {
 
 			Map<String, String> form = new HashMap<String, String>();
 			form.put("username", "lockeduser");
@@ -118,7 +118,7 @@ public class LoginUserTest {
 
 			int newLoginAttempts = dao.findByUsername("lockeduser").getLoginAttempts();
 
-			if (i <= DatabaseAuthenticationProvider.MAX_LOGIN_ATTEMMPTS) {
+			if (i <= DatabaseAuthenticationProvider.MAX_LOGIN_ATTEMPTS) {
 				// check login counter
 				assertEquals(oldLoginAttempts + 1, newLoginAttempts);
 				oldLoginAttempts = newLoginAttempts;

--- a/src/test/java/cloudgene/mapred/util/GitHubUtilTest.java
+++ b/src/test/java/cloudgene/mapred/util/GitHubUtilTest.java
@@ -1,8 +1,11 @@
 package cloudgene.mapred.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
+import cloudgene.mapred.util.GitHubUtil.Repository;
 
 public class GitHubUtilTest {
 
@@ -11,8 +14,8 @@ public class GitHubUtilTest {
 		assertTrue(true);
 	}
 	
-	
-/*	public void testParseShorthand() {
+	@Test
+	public void testParseShorthand() {
 		// username/repo[/subdir][@ref]
 
 		Repository repo = GitHubUtil.parseShorthand("genepi");
@@ -52,6 +55,7 @@ public class GitHubUtilTest {
 		assertEquals("1.1.0", repo.getTag());
 	}
 
+	@Test
 	public void testBuildUrlFromRepository() {
 		Repository repository = new Repository();
 		repository.setUser("genepi");
@@ -74,7 +78,8 @@ public class GitHubUtilTest {
 		assertEquals("https://api.github.com/repos/genepi/imputationserver/zipball/1.0.2",
 				GitHubUtil.buildUrlFromRepository(repository));
 	}
-
+	
+	@Test
 	public void testGetLatestReleaseFromRepository() {
 		Repository repository = new Repository();
 		repository.setUser("lukfor");
@@ -87,5 +92,5 @@ public class GitHubUtilTest {
 		assertEquals("https://api.github.com/repos/lukfor/hello-cloudgene/zipball/1.2.0",
 				GitHubUtil.buildUrlFromRepository(repository));
 	}
-*/
+
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -12,4 +12,9 @@
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
+    
+    <logger name="org.apache.hadoop" level="OFF"/>
+    <logger name="org.mortbay.log" level="OFF"/>
+    <logger name="BlockStateChange" level="OFF"/>
+    
 </configuration>


### PR DESCRIPTION
This PR migrates logging from common-logging to sl4j to take advantage of micronaut-logging. In addition, it transfers all logging messages from PR https://github.com/genepi/cloudgene/pull/95 to new controllers and services.