### PR TITLE
Update Google analytics code to use new GA4 trackers

### DIFF
--- a/src/main/html/webapp/public/index.html
+++ b/src/main/html/webapp/public/index.html
@@ -26,18 +26,17 @@
     <script src="./dist/bundles/cloudgene/index.js"></script>
 
     <#if google_analytics??>
-      <!-- Google Analytics -->
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=${google_analytics}"></script>
       <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-      ga('create', ' ${google_analytics}', 'auto');
-      ga('send', 'pageview');
-
+        // Automatically sends a pageview with specified Tag ID
+        gtag('config', '${google_analytics}');
       </script>
-    	<!-- End Google Analytics -->
+      <!-- End Google Analytics -->
     </#if>
 
   </body>


### PR DESCRIPTION
## Purpose
Fix #108 . This is a very simplistic migration for coarse-grained pageview tracking of visits to TIS. It does not use any advanced features, such as feature-level event based analytics.
https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs

Preliminary evaluation suggests that neither TIS nor MIS are presently using the GA integration feature (no tracker defined via admin panel). Thus we expect minimal impact on existing deployments. The prior google analytics version stopped collecting data in July 2023, hence no old sites will lose the ability to collect analytics if this code is changed.

## Deployment Notes
Due to user privacy concerns, we should take care to minimize sensitive data collection where possible.

We have created a GA4 property with many default features explicitly turned off. We have deauthorized third party sharing, google support access, "user-provided data capabilities", scrolling, form, and file download tracking, and ad integrations. To deploy this consistently, the UM terraform repos will need to be modified to include the GA tracking code whenever the config file is regenerated (for a new server).

## Testing notes
It typically takes 12-72 hr for analytics events to become visible in the GA dashboard. Browser extensions such as ublock origin may interfere with testing this feature.

Per UM team policy, UM PIs have been given admin-level access to the TIS GA project as contacts of record.

No events are sent for navigation to sub-pages. Preliminary evaluation suggests that CG uses hash-based routes, rather than the JS history manipulation API; this style of URL manipulation is not automatically captured by the analytics tool.