### PR TITLE
Add database indices to frequent queries

### DIFF
--- a/src/main/sql/updates.sql
+++ b/src/main/sql/updates.sql
@@ -169,3 +169,11 @@ alter table job add column user_agent VARCHAR (400);
 
 -- 2.6.0
 alter table `user` add column api_token_expires_on timestamp null default null;
+
+-- 2.7.1
+CREATE INDEX idx_downloads_hash ON downloads(hash);
+CREATE INDEX idx_downloads_path ON downloads(path);
+
+CREATE INDEX idx_user_username ON user(username);
+CREATE INDEX idx_user_mail ON user(mail);
+CREATE INDEX idx_user_fullname ON user(full_name);

--- a/src/main/sql/updates.sql
+++ b/src/main/sql/updates.sql
@@ -170,7 +170,7 @@ alter table job add column user_agent VARCHAR (400);
 -- 2.6.0
 alter table `user` add column api_token_expires_on timestamp null default null;
 
--- 2.7.1
+-- 2.8.1
 CREATE INDEX idx_downloads_hash ON downloads(hash);
 CREATE INDEX idx_downloads_path ON downloads(path);
 


### PR DESCRIPTION
🦑 This PR has not yet been fully tested as part of the release process, but I'm tracking the change so it isn't forgotten.

## Purpose
Adds indices to columns that are commonly used as the WHERE clause in DAO queries in this codebase. Some tables, such as `downloads`, are very large and were performing very inefficient lookups.

This is partial mitigation for the recent database-related downtime incident report (see slack).

## How to test this
Build and test release with this migration. Use `EXPLAIN <query>` to verify that index is being used.

Note: By reviewing the mysql slow query log, I've verified that this should cover most of the common slow query use cases. (downloads table was by far the worst offender across all query types)