### PR TITLE
Allow to configure user registration without email

### DIFF
--- a/src/main/html/webapp/components/core/user/profile/profile.js
+++ b/src/main/html/webapp/components/core/user/profile/profile.js
@@ -23,11 +23,28 @@ export default Control.extend({
     }, function(user) {
       $(element).html(template({
         user: user,
-        emailRequired: options.appState.attr('emailRequired')
+        anonymousAccount: (!options.appState.attr('emailRequired')),
+        emailProvided: (user.attr('mail') != "" && user.attr('mail') != undefined),
+        userEmailDescription: options.appState.attr('userEmailDescription'),
+        userWithoutEmailDescription: options.appState.attr('userWithoutEmailDescription')
       }));
       options.user = user;
       $(element).fadeIn();
     });
+  },
+
+  "#anonymous click" : function(){
+    if (!this.emailRequired){
+      var anonymousControl = $(this.element).find("[name='anonymous']");
+      var anonymous = !anonymousControl.is(':checked');
+      var mail = $(this.element).find("[name='mail']");
+      if (anonymous){
+        mail.attr('disabled','disabled');
+      } else {
+        mail.removeAttr('disabled');
+      }
+      mail.val("");
+    }
   },
 
   'submit': function(element, event) {
@@ -39,9 +56,15 @@ export default Control.extend({
     var fullnameError = user.checkName(fullname.val());
     this.updateControl(fullname, fullnameError);
 
+    var anonymous = false;
+    if (!this.emailRequired){
+      var anonymousControl = $(this.element).find("[name='anonymous']");
+      anonymous = !anonymousControl.is(':checked');
+    }
+
     // mail
     var mail = $(element).find("[name='mail']");
-    if (!this.emailRequired && mail.val() != ""){
+    if (!anonymous){
       var mailError = user.checkMail(mail.val());
       this.updateControl(mail, mailError);
     } else {

--- a/src/main/html/webapp/components/core/user/profile/profile.js
+++ b/src/main/html/webapp/components/core/user/profile/profile.js
@@ -16,13 +16,14 @@ import templateNewTokenDialog from './dialogs/new.stache'
 export default Control.extend({
 
   "init": function(element, options) {
-
+    this.emailRequired = options.appState.attr('emailRequired');
     $(element).hide();
     User.findOne({
       user: 'me'
     }, function(user) {
       $(element).html(template({
-        user: user
+        user: user,
+        emailRequired: options.appState.attr('emailRequired')
       }));
       options.user = user;
       $(element).fadeIn();
@@ -40,8 +41,12 @@ export default Control.extend({
 
     // mail
     var mail = $(element).find("[name='mail']");
-    var mailError = user.checkMail(mail.val());
-    this.updateControl(mail, mailError);
+    if (!this.emailRequired && mail.val() != ""){
+      var mailError = user.checkMail(mail.val());
+      this.updateControl(mail, mailError);
+    } else {
+      this.updateControl(mail, undefined);
+    }
 
     // password if password is not empty. else no password update on server side
     var newPassword = $(element).find("[name='new-password']");

--- a/src/main/html/webapp/components/core/user/profile/profile.stache
+++ b/src/main/html/webapp/components/core/user/profile/profile.stache
@@ -16,11 +16,33 @@ Please fill out the form below to change your account settings or your password.
 		<div class="invalid-feedback"></div>
 	</div>
 
+  {{#is(anonymousAccount, false)}}
+
 	<div class="form-group">
 		<label for="mail" class="control-label">E-Mail:</label>
 		<input id="mail" name="mail" type="text" value="{{user.mail}}" class="form-control col-sm-3">
 		<div class="invalid-feedback"></div>
 	</div>
+
+	{{else}}
+	<hr>
+  <div class="form-group">
+   <input type="checkbox" id="anonymous" name="anonymous" value="0" {{#emailProvided}}checked{{/emailProvided}}> <label for="anonymous" class="control-label">E-Mail Address</label>
+    <div class="form-group" style="margin-left: 30px;">
+      <p>
+     {{userEmailDescription}}
+      </p>
+      <label for="mail" class="control-label">E-Mail:</label>
+      <input id="mail" name="mail" type="text" class="form-control col-sm-3" autocomplete="off" {{#is(emailProvided, false)}}disabled{{/is}} value="{{user.mail}}">
+      <div class="invalid-feedback"></div>
+      <p><br>
+        {{userWithoutEmailDescription}}
+      </p>
+    </div>
+     </div>
+       <hr>
+
+	{{/is}}
 
 	<h4>Change password</h4>
 
@@ -58,7 +80,7 @@ Please fill out the form below to change your account settings or your password.
   <small class="{{#is(../user.apiTokenValid, false)}}text-danger{{#is}}">{{../user.apiTokenMessage}}</small>
 	{{else}}
 		<button class="btn btn-primary" id="create_token">Create API Token</button>
-		Expires in 
+		Expires in
 		<select  id="token_expiration">
 			<option value="30">30 days</option>
 			<option value="60">60 days</option>

--- a/src/main/html/webapp/components/core/user/profile/profile.stache
+++ b/src/main/html/webapp/components/core/user/profile/profile.stache
@@ -63,9 +63,9 @@ Please fill out the form below to change your account settings or your password.
 
 	</div>
 </form>
-
+<br>
 <hr>
-
+<br>
 <h3>API Access</h3>
 
 <p>This service provides a rich RestAPI to submit, monitor and download jobs.</p>
@@ -88,9 +88,9 @@ Please fill out the form below to change your account settings or your password.
 
 
 {{/user.hasApiToken}}
-
+<br>
 <hr>
-
+<br>
 <h3>Delete Account</h3>
 
 <p>Once you delete your user account, there is no going back. Please be certain.</p>

--- a/src/main/html/webapp/components/core/user/signup/signup.js
+++ b/src/main/html/webapp/components/core/user/signup/signup.js
@@ -9,8 +9,11 @@ import template from './signup.stache';
 export default Control.extend({
 
   "init": function(element, options) {
+    this.emailRequired = options.appState.attr('emailRequired');
     $(element).hide();
-    $(element).html(template());
+    $(element).html(template({
+      emailRequired: options.appState.attr('emailRequired')
+    }));
     $(element).fadeIn();
   },
 
@@ -32,8 +35,10 @@ export default Control.extend({
 
     // mail
     var mail = $(element).find("[name='mail']");
-    var mailError = user.checkMail(mail.val());
-    this.updateControl(mail, mailError);
+    if (this.emailRequired || (mail.val() != "")){
+      var mailError = user.checkMail(mail.val());
+      this.updateControl(mail, mailError);
+    }
 
     // password
     var newPassword = $(element).find("[name='new-password']");

--- a/src/main/html/webapp/components/core/user/signup/signup.js
+++ b/src/main/html/webapp/components/core/user/signup/signup.js
@@ -12,16 +12,49 @@ export default Control.extend({
     this.emailRequired = options.appState.attr('emailRequired');
     $(element).hide();
     $(element).html(template({
-      emailRequired: options.appState.attr('emailRequired')
+      emailRequired: options.appState.attr('emailRequired'),
+      userEmailDescription: options.appState.attr('userEmailDescription'),
+      userWithoutEmailDescription: options.appState.attr('userWithoutEmailDescription')
     }));
     $(element).fadeIn();
   },
+
+  "#anonymous1 click" : function(){
+    this.updateEmailControl();
+  },
+
+  "#anonymous2 click" : function(){
+    this.updateEmailControl();
+  },
+
+  "updateEmailControl": function() {
+      if (!this.emailRequired){
+        var anonymousControl = $(this.element).find("[name='anonymous']:checked");
+        var anonymous = (anonymousControl.val() == "1");
+        console.log(anonymous);
+        var mail = $(this.element).find("[name='mail']");
+        console.log(mail);
+        if (anonymous){
+          mail.attr('disabled','disabled');
+        } else {
+          mail.removeAttr('disabled');
+        }
+      }
+   },
 
   'submit': function(element, event) {
     event.preventDefault();
 
     var that = this;
     var user = new User();
+
+    // anonymous radiobutton
+    var anonymous = false;
+
+    if (!this.emailRequired){
+      var anonymousControl = $(element).find("[name='anonymous']:checked");
+      anonymous = (anonymousControl.val() == "1");
+    }
 
     // username
     var username = $(element).find("[name='username']");
@@ -35,9 +68,11 @@ export default Control.extend({
 
     // mail
     var mail = $(element).find("[name='mail']");
-    if (this.emailRequired || (mail.val() != "")){
+    if (!anonymous){
       var mailError = user.checkMail(mail.val());
       this.updateControl(mail, mailError);
+    } else {
+      this.updateControl(mail, undefined);
     }
 
     // password

--- a/src/main/html/webapp/components/core/user/signup/signup.js
+++ b/src/main/html/webapp/components/core/user/signup/signup.js
@@ -31,9 +31,7 @@ export default Control.extend({
       if (!this.emailRequired){
         var anonymousControl = $(this.element).find("[name='anonymous']:checked");
         var anonymous = (anonymousControl.val() == "1");
-        console.log(anonymous);
         var mail = $(this.element).find("[name='mail']");
-        console.log(mail);
         if (anonymous){
           mail.attr('disabled','disabled');
         } else {

--- a/src/main/html/webapp/components/core/user/signup/signup.stache
+++ b/src/main/html/webapp/components/core/user/signup/signup.stache
@@ -21,13 +21,35 @@
     <div class="invalid-feedback"></div>
   </div>
 
-<p>Email Required: {{emailRequired}} </p>
+  {{#is(emailRequired, true)}}
 
   <div class="form-group">
     <label for="mail" class="control-label">E-Mail:</label>
     <input id="mail" name="mail" type="text" class="form-control col-sm-3" autocomplete="off">
     <div class="invalid-feedback"></div>
   </div>
+
+  {{else}}
+    <hr>
+  <div class="form-group">
+   <input type="radio" id="anonymous1" name="anonymous" value="0" checked> <label for="anonymous1" class="control-label">E-Mail Address</label>
+    <div class="form-group" style="margin-left: 30px;">
+      <p>
+     {{userEmailDescription}}
+      </p>
+      <label for="mail" class="control-label">E-Mail:</label>
+      <input id="mail" name="mail" type="text" class="form-control col-sm-3" autocomplete="off">
+      <div class="invalid-feedback"></div>
+    </div>
+   <input type="radio" id="anonymous2" name="anonymous" value="1"> <label for="anonymous2" class="control-label">I don't want to provide my email address</label>
+   <div class="form-group" style="margin-left: 30px;">
+     <p>
+      {{userWithoutEmailDescription}}
+     </p>
+    </div>
+   </div>
+     <hr>
+  {{/is}}
 
   <div class="form-group">
     <label for="new-password" class="control-label">Password:</label>

--- a/src/main/html/webapp/components/core/user/signup/signup.stache
+++ b/src/main/html/webapp/components/core/user/signup/signup.stache
@@ -21,6 +21,7 @@
     <div class="invalid-feedback"></div>
   </div>
 
+<p>Email Required: {{emailRequired}} </p>
 
   <div class="form-group">
     <label for="mail" class="control-label">E-Mail:</label>

--- a/src/main/html/webapp/components/core/user/signup/signup.stache
+++ b/src/main/html/webapp/components/core/user/signup/signup.stache
@@ -2,7 +2,11 @@
 <br>
 
 <div class="alert alert-success" id="success-message" style="display: none;">
-  <b>Well done!</b> An email including the activation code has been sent to your address.
+  {{#is(emailRequired, true)}}
+    <b>Well done!</b> An email including the activation code has been sent to your address.
+  {{else}}
+    <b>Well done!</b> Your account is now active. <a href="/">Login now</a>.
+   {{/is}}
   <br>
 </div>
 

--- a/src/main/java/cloudgene/mapred/api/v2/server/Server.java
+++ b/src/main/java/cloudgene/mapred/api/v2/server/Server.java
@@ -27,6 +27,8 @@ public class Server extends BaseResource {
 		data.put("foreground", getSettings().getColors().get("foreground"));
 		data.put("footer", getWebApp().getTemplate(Template.FOOTER));
 		data.put("emailRequired", getSettings().isEmailRequired());
+		data.put("userEmailDescription", getWebApp().getTemplate(Template.USER_EMAIL_DESCRIPTION));
+		data.put("userWithoutEmailDescription", getWebApp().getTemplate(Template.USER_WITHOUT_EMAIL_DESCRIPTION));
 		if (user != null) {
 			JSONObject userJson = new JSONObject();
 			userJson.put("username", user.getUsername());

--- a/src/main/java/cloudgene/mapred/api/v2/server/Server.java
+++ b/src/main/java/cloudgene/mapred/api/v2/server/Server.java
@@ -26,6 +26,7 @@ public class Server extends BaseResource {
 		data.put("background", getSettings().getColors().get("background"));
 		data.put("foreground", getSettings().getColors().get("foreground"));
 		data.put("footer", getWebApp().getTemplate(Template.FOOTER));
+		data.put("emailRequired", getSettings().isEmailRequired());
 		if (user != null) {
 			JSONObject userJson = new JSONObject();
 			userJson.put("username", user.getUsername());

--- a/src/main/java/cloudgene/mapred/api/v2/users/RegisterUser.java
+++ b/src/main/java/cloudgene/mapred/api/v2/users/RegisterUser.java
@@ -21,7 +21,7 @@ public class RegisterUser extends BaseResource {
 
 	public static final String DEFAULT_ROLE = "User";
 
-	public static final String DEFAULT_UNTRUSTED_ROLE = "User_Untrusted";
+	public static final String DEFAULT_ANONYMOUS_ROLE = "Anonymous_User";
 
 	@Post
 	public Representation post(Representation entity) {
@@ -58,7 +58,7 @@ public class RegisterUser extends BaseResource {
 			}
 		}
 
-		String[] roles = new String[] { mailProvided ? DEFAULT_ROLE : DEFAULT_UNTRUSTED_ROLE};
+		String[] roles = new String[] { mailProvided ? DEFAULT_ROLE : DEFAULT_ANONYMOUS_ROLE};
 
 		// check password
 		error = User.checkPassword(newPassword, confirmNewPassword);

--- a/src/main/java/cloudgene/mapred/api/v2/users/RegisterUser.java
+++ b/src/main/java/cloudgene/mapred/api/v2/users/RegisterUser.java
@@ -14,10 +14,14 @@ import cloudgene.mapred.util.HashUtil;
 import cloudgene.mapred.util.MailUtil;
 import cloudgene.mapred.util.Template;
 
+import java.util.Arrays;
+
 public class RegisterUser extends BaseResource {
 	private static final Log log = LogFactory.getLog(RegisterUser.class);
 
 	public static final String DEFAULT_ROLE = "User";
+
+	public static final String DEFAULT_UNTRUSTED_ROLE = "User_Untrusted";
 
 	@Post
 	public Representation post(Representation entity) {
@@ -27,7 +31,7 @@ public class RegisterUser extends BaseResource {
 		Form form = new Form(entity);
 		String username = form.getFirstValue("username");
 		String fullname = form.getFirstValue("full-name");
-		String mail = form.getFirstValue("mail").toString();
+		String mail = form.getFirstValue("mail");
 		String newPassword = form.getFirstValue("new-password");
 		String confirmNewPassword = form.getFirstValue("confirm-new-password");
 
@@ -41,14 +45,20 @@ public class RegisterUser extends BaseResource {
 			return new JSONAnswer("Username already exists.", false);
 		}
 
-		// check email
-		error = User.checkMail(mail);
-		if (error != null) {
-			return new JSONAnswer(error, false);
+		boolean mailProvided = (mail != null && !mail.isEmpty());
+
+		if (getSettings().isEmailRequired() || mailProvided) {
+			// check email
+			error = User.checkMail(mail);
+			if (error != null) {
+				return new JSONAnswer(error, false);
+			}
+			if (dao.findByMail(mail) != null) {
+				return new JSONAnswer("E-Mail is already registered.", false);
+			}
 		}
-		if (dao.findByMail(mail) != null) {
-			return new JSONAnswer("E-Mail is already registered.", false);
-		}
+
+		String[] roles = new String[] { mailProvided ? DEFAULT_ROLE : DEFAULT_UNTRUSTED_ROLE};
 
 		// check password
 		error = User.checkPassword(newPassword, confirmNewPassword);
@@ -66,7 +76,7 @@ public class RegisterUser extends BaseResource {
 		newUser.setUsername(username);
 		newUser.setFullName(fullname);
 		newUser.setMail(mail);
-		newUser.setRoles(new String[] { DEFAULT_ROLE });
+		newUser.setRoles(roles);
 		newUser.setPassword(HashUtil.hashPassword(newPassword));
 
 		try {
@@ -74,7 +84,7 @@ public class RegisterUser extends BaseResource {
 			// if email server configured, send mails with activation link. Else
 			// activate user immediately.
 
-			if (getSettings().getMail() != null) {
+			if (getSettings().getMail() != null && mailProvided) {
 
 				String activationKey = HashUtil.getActivationHash(newUser);
 				newUser.setActive(false);
@@ -95,7 +105,8 @@ public class RegisterUser extends BaseResource {
 
 			}
 
-			log.info(String.format("Registration: New user %s (ID %s - email %s)", newUser.getUsername(), newUser.getId(), newUser.getMail()));
+			log.info(String.format("Registration: New user %s (ID %s - email %s - roles %s)", newUser.getUsername(),
+					newUser.getId(), newUser.getMail(), Arrays.toString(newUser.getRoles())));
 			MailUtil.notifySlack(getSettings(), "Hi! say hello to " + username + " (" + mail + ") :hugging_face:");
 
 			dao.insert(newUser);

--- a/src/main/java/cloudgene/mapred/api/v2/users/ResetPassword.java
+++ b/src/main/java/cloudgene/mapred/api/v2/users/ResetPassword.java
@@ -25,7 +25,7 @@ public class ResetPassword extends BaseResource {
 		Form form = new Form(entity);
 		String username = form.getFirstValue("username");
 
-		if (username == null || username.isEmpty()) {
+		if (username == null || username.trim().isEmpty()) {
 			return new JSONAnswer("Please enter a valid username or email address.", false);
 		}
 
@@ -66,13 +66,17 @@ public class ResetPassword extends BaseResource {
 			String body = getWebApp().getTemplate(Template.RECOVERY_MAIL, user.getFullName(), application, link);
 
 			try {
-				log.info(String.format("Password reset link requested for user '%s'", username));
-				MailUtil.notifySlack(getSettings(), "Hi! " + username + " asked for a new password :key:");
 
-				MailUtil.send(getSettings(), user.getMail(), subject, body);
+				if (user.getMail()!= null && !user.getMail().isEmpty()) {
+					log.info(String.format("Password reset link requested for user '%s'", username));
+					MailUtil.notifySlack(getSettings(), "Hi! " + username + " asked for a new password :key:");
+					MailUtil.send(getSettings(), user.getMail(), subject, body);
 
-				return new JSONAnswer(
-						"Email sent to " + user.getMail() + " with instructions on how to reset your password.", true);
+					return new JSONAnswer(
+							"We sent you an email with instructions on how to reset your password.", true);
+				} else {
+					return new JSONAnswer("No email address is associated with the provided username. Therefore, password recovery cannot be completed.", false);
+				}
 
 			} catch (Exception e) {
 

--- a/src/main/java/cloudgene/mapred/api/v2/users/UserProfile.java
+++ b/src/main/java/cloudgene/mapred/api/v2/users/UserProfile.java
@@ -11,7 +11,6 @@ import org.restlet.resource.Delete;
 import org.restlet.resource.Get;
 import org.restlet.resource.Post;
 
-import cloudgene.mapred.core.ApiTokenVerifier;
 import cloudgene.mapred.core.User;
 import cloudgene.mapred.database.UserDao;
 import cloudgene.mapred.representations.JSONAnswer;
@@ -98,15 +97,18 @@ public class UserProfile extends BaseResource {
 					newUser.getId()));
 		}
 
+		String roleMessage = " ";
 		if (!getSettings().isEmailRequired()) {
 			if ((newUser.getMail() == null || newUser.getMail().isEmpty()) && user.hasRole(RegisterUser.DEFAULT_ROLE)) {
-				newUser.replaceRole(RegisterUser.DEFAULT_ROLE, RegisterUser.DEFAULT_UNTRUSTED_ROLE);
-				log.info(String.format("User: changed role to %s for user %s (ID %s)", RegisterUser.DEFAULT_UNTRUSTED_ROLE, newUser.getUsername(),
+				newUser.replaceRole(RegisterUser.DEFAULT_ROLE, RegisterUser.DEFAULT_ANONYMOUS_ROLE);
+				log.info(String.format("User: changed role to %s for user %s (ID %s)", RegisterUser.DEFAULT_ANONYMOUS_ROLE, newUser.getUsername(),
 						newUser.getId()));
-			} else if ((newUser.getMail() != null && !newUser.getMail().isEmpty()) && user.hasRole(RegisterUser.DEFAULT_UNTRUSTED_ROLE)) {
-				newUser.replaceRole(RegisterUser.DEFAULT_UNTRUSTED_ROLE, RegisterUser.DEFAULT_ROLE);
+				roleMessage += "<br><br>Your account has been <b>downgraded</b>.<br>To apply these changes, please log out and log back in.";
+			} else if ((newUser.getMail() != null && !newUser.getMail().isEmpty()) && user.hasRole(RegisterUser.DEFAULT_ANONYMOUS_ROLE)) {
+				newUser.replaceRole(RegisterUser.DEFAULT_ANONYMOUS_ROLE, RegisterUser.DEFAULT_ROLE);
 				log.info(String.format("User: changed role to %s for user %s (ID %s)", RegisterUser.DEFAULT_ROLE, newUser.getUsername(),
 						newUser.getId()));
+				roleMessage += "<br><br>Your account has been <b>upgraded</b>.<br>To apply these changes, please log out and log back in.";
 			}
 		}
 
@@ -126,7 +128,7 @@ public class UserProfile extends BaseResource {
 
 		dao.update(newUser);
 
-		return new JSONAnswer("User profile sucessfully updated.", true);
+		return new JSONAnswer("User profile successfully updated." + roleMessage , true);
 
 	}
 

--- a/src/main/java/cloudgene/mapred/core/User.java
+++ b/src/main/java/cloudgene/mapred/core/User.java
@@ -234,4 +234,12 @@ public class User {
 		return ((User) obj).getUsername().equals(username);
 	}
 
+	public void replaceRole(String oldRole, String newRole) {
+		for (int i = 0; i < roles.length; i++) {
+			if (roles[i].equalsIgnoreCase(oldRole)) {
+				roles[i] = newRole;
+				return;
+			}
+		}
+	}
 }

--- a/src/main/java/cloudgene/mapred/util/JSONConverter.java
+++ b/src/main/java/cloudgene/mapred/util/JSONConverter.java
@@ -30,12 +30,12 @@ public class JSONConverter {
 	public static JSONObject convert(AbstractJob job) {
 
 		JsonConfig config = new JsonConfig();
-		config.setExcludes(new String[] { "user", "inputParams", "output", "error", "s3Url", "task", "config",
+		config.setExcludes(new String[]{"user", "inputParams", "output", "error", "s3Url", "task", "config",
 				"mapReduceJob", "job", "step", "context", "hdfsWorkspace", "localWorkspace", "logOutFiles",
 				"removeHdfsWorkspace", "settings", "setupComplete", "stdOutFile", "workingDirectory", "parameter",
 				"logOutFile", "map", "reduce", "mapProgress", "reduceProgress", "jobId", "makeAbsolute", "mergeOutput",
 				"removeHeader", "value", "autoExport", "download", "tip", "apiToken", "parameterId", "count",
-				"username" });
+				"username"});
 
 		// create tree
 		for (CloudgeneParameterOutput param : job.getOutputParams()) {
@@ -122,18 +122,14 @@ public class JSONConverter {
 						valuesObject.put("key", "apps@" + app.getId());
 						valuesObject.put("label", app.getName());
 						// TODO: check null and instance of map
-						Map values = (Map) app.getProperties().get(property);
-						JSONArray array2 = new JSONArray();
-						for (Object key : values.keySet()) {
-							JSONObject valuesObject2 = new JSONObject();
-							String value = values.get(key).toString();
-							valuesObject2.put("key", key.toString());
-							valuesObject2.put("value", value);
-							valuesObject2.put("enabled", false);
-							array2.add(valuesObject2);
+						Object values = app.getProperties().get(property);
+						if (values instanceof Map){
+							JSONArray array2 = buildFromMap((Map)values);
+							valuesObject.put("values", array2);
+						} else if (values instanceof List){
+							JSONArray array2 = buildFromList((List)values);
+							valuesObject.put("values", array2);
 						}
-
-						valuesObject.put("values", array2);
 						array.add(valuesObject);
 
 					}
@@ -268,6 +264,33 @@ public class JSONConverter {
 			object.put("source", FileUtil.readFileAsString(application.getFilename()));
 		}
 		return object;
+	}
+
+	private static JSONArray buildFromMap(Map values){
+		JSONArray array = new JSONArray();
+		for(Object key :values.keySet()){
+			JSONObject valuesObject2 = new JSONObject();
+			String value = values.get(key).toString();
+			valuesObject2.put("key", key.toString());
+			valuesObject2.put("value", value);
+			valuesObject2.put("enabled", false);
+			array.add(valuesObject2);
+		}
+		return array;
+	}
+
+	private static JSONArray buildFromList(List<Map> values){
+		JSONArray array = new JSONArray();
+		for (Map object : values) {
+			if (object.containsKey("id") && object.containsKey("name")) {
+				JSONObject valuesObject2 = new JSONObject();
+				valuesObject2.put("key",object.get("id").toString());
+				valuesObject2.put("value", object.get("name").toString());
+				valuesObject2.put("enabled", false);
+				array.add(valuesObject2);
+			}
+		}
+		return array;
 	}
 
 }

--- a/src/main/java/cloudgene/mapred/util/Settings.java
+++ b/src/main/java/cloudgene/mapred/util/Settings.java
@@ -70,6 +70,8 @@ public class Settings {
 
 	private int maxRunningJobsPerUser = 2;
 
+	private boolean emailRequired = true;
+
 	private boolean autoRetire = false;
 
 	private boolean streaming = true;
@@ -717,4 +719,11 @@ public class Settings {
 		return serverUrl;
 	}
 
+	public boolean isEmailRequired() {
+		return emailRequired;
+	}
+
+	public void setEmailRequired(boolean emailRequired) {
+		this.emailRequired = emailRequired;
+	}
 }

--- a/src/main/java/cloudgene/mapred/util/Template.java
+++ b/src/main/java/cloudgene/mapred/util/Template.java
@@ -15,6 +15,10 @@ public class Template {
 	public static final String FOOTER_SUBMIT_JOB = "FOOTER_SUBMIT_JOB";
 
 	public static final String TERMS = "TERMS";
+
+	public static final String USER_EMAIL_DESCRIPTION = "USER_EMAIL_DESCRIPTION";
+
+	public static final String USER_WITHOUT_EMAIL_DESCRIPTION = "USER_WITHOUT_EMAIL_DESCRIPTION";
 	
 	public static final Template[] SNIPPETS = new Template[] {
 
@@ -39,7 +43,11 @@ public class Template {
 			new Template(FOOTER_SUBMIT_JOB, ""),
 			
 			new Template(TERMS, "I will not attempt to re-identify or contact research participants.<br>" + 
-					"I will report any inadvertent data release, security breach or other data management incident of which I become aware.")
+					"I will report any inadvertent data release, security breach or other data management incident of which I become aware."),
+
+			new Template(USER_EMAIL_DESCRIPTION, "Receive email notifications when jobs are completed."),
+
+			new Template(USER_WITHOUT_EMAIL_DESCRIPTION, "You can enter your email address at any time to upgrade your account.")
 
 	};
 

--- a/src/test/java/cloudgene/mapred/api/v2/users/RegisterUserTest.java
+++ b/src/test/java/cloudgene/mapred/api/v2/users/RegisterUserTest.java
@@ -271,7 +271,7 @@ public class RegisterUserTest extends JobsApiTestCase {
 		UserDao dao = new UserDao(TestServer.getInstance().getDatabase());
 		User user = dao.findByUsername("abcdefgh");
 		assertEquals(1, user.getRoles().length);
-		assertEquals(RegisterUser.DEFAULT_UNTRUSTED_ROLE, user.getRoles()[0]);
+		assertEquals(RegisterUser.DEFAULT_ANONYMOUS_ROLE, user.getRoles()[0]);
 	}
 
 	public void testWithMailAndNoMailRequired() throws JSONException, IOException {

--- a/src/test/java/cloudgene/mapred/api/v2/users/RegisterUserTest.java
+++ b/src/test/java/cloudgene/mapred/api/v2/users/RegisterUserTest.java
@@ -2,6 +2,8 @@ package cloudgene.mapred.api.v2.users;
 
 import java.io.IOException;
 
+import cloudgene.mapred.core.User;
+import cloudgene.mapred.database.UserDao;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.restlet.data.Form;
@@ -82,6 +84,12 @@ public class RegisterUserTest extends JobsApiTestCase {
 		assertEquals("E-Mail is already registered.", object.get("message"));
 		assertEquals(mailsBefore, mailServer.getReceivedEmailSize());
 		resource.release();
+
+		//check role
+		UserDao dao = new UserDao(TestServer.getInstance().getDatabase());
+		User user = dao.findByUsername("usernameunique");
+		assertEquals(1, user.getRoles().length);
+		assertEquals(RegisterUser.DEFAULT_ROLE, user.getRoles()[0]);
 	}
 
 	public void testWithEmptyUsername() throws JSONException, IOException {
@@ -228,6 +236,77 @@ public class RegisterUserTest extends JobsApiTestCase {
 		assertTrue(object.get("message").toString().contains("E-Mail is required."));
 		assertEquals(mailsBefore, mailServer.getReceivedEmailSize());
 		resource.release();
+
+	}
+
+	public void testWithEmptyMailAndNoMailRequired() throws JSONException, IOException {
+
+		//set email required to false.
+
+		TestServer.getInstance().getSettings().setEmailRequired(false);
+
+		TestMailServer mailServer = TestMailServer.getInstance();
+		int mailsBefore = mailServer.getReceivedEmailSize();
+
+		Form form = new Form();
+		form.set("username", "abcdefgh");
+		form.set("full-name", "abcdefgh abcgd");
+		form.set("mail", "");
+		form.set("new-password", "Password27");
+		form.set("confirm-new-password", "Password27");
+
+		// register user
+		ClientResource resource = createClientResource("/api/v2/users/register");
+		resource.post(form);
+		assertEquals(200, resource.getStatus().getCode());
+		JSONObject object = new JSONObject(resource.getResponseEntity().getText());
+		assertEquals(object.get("success"), true);
+		assertEquals("User sucessfully created.", object.get("message"));
+		assertEquals(mailsBefore, mailServer.getReceivedEmailSize());
+		resource.release();
+
+		TestServer.getInstance().getSettings().setEmailRequired(true);
+
+		//check role
+		UserDao dao = new UserDao(TestServer.getInstance().getDatabase());
+		User user = dao.findByUsername("abcdefgh");
+		assertEquals(1, user.getRoles().length);
+		assertEquals(RegisterUser.DEFAULT_UNTRUSTED_ROLE, user.getRoles()[0]);
+	}
+
+	public void testWithMailAndNoMailRequired() throws JSONException, IOException {
+
+		//set email required to false.
+
+		TestServer.getInstance().getSettings().setEmailRequired(false);
+
+		TestMailServer mailServer = TestMailServer.getInstance();
+		int mailsBefore = mailServer.getReceivedEmailSize();
+
+		Form form = new Form();
+		form.set("username", "abcdefghi");
+		form.set("full-name", "abcdefgh abcgd");
+		form.set("mail", "test-blabla@test.com");
+		form.set("new-password", "Password27");
+		form.set("confirm-new-password", "Password27");
+
+		// register user
+		ClientResource resource = createClientResource("/api/v2/users/register");
+		resource.post(form);
+		assertEquals(200, resource.getStatus().getCode());
+		JSONObject object = new JSONObject(resource.getResponseEntity().getText());
+		assertEquals(object.get("success"), true);
+		assertEquals("User sucessfully created.", object.get("message"));
+		assertEquals(mailsBefore + 1, mailServer.getReceivedEmailSize());
+		resource.release();
+
+		TestServer.getInstance().getSettings().setEmailRequired(true);
+
+		//check role
+		UserDao dao = new UserDao(TestServer.getInstance().getDatabase());
+		User user = dao.findByUsername("abcdefghi");
+		assertEquals(1, user.getRoles().length);
+		assertEquals(RegisterUser.DEFAULT_ROLE, user.getRoles()[0]);
 	}
 
 	public void testWithWrongMail() throws JSONException, IOException {

--- a/src/test/java/cloudgene/mapred/api/v2/users/ResetPasswordTest.java
+++ b/src/test/java/cloudgene/mapred/api/v2/users/ResetPasswordTest.java
@@ -140,7 +140,7 @@ public class ResetPasswordTest extends JobsApiTestCase {
 		assertEquals(200, resource.getStatus().getCode());
 		JSONObject object = new JSONObject(resource.getResponseEntity().getText());
 		assertEquals(object.get("success"), true);
-		assertTrue(object.get("message").toString().contains("Email sent to"));
+		assertTrue(object.get("message").toString().contains("We sent you an email"));
 		assertEquals(mailsBefore + 1, mailServer.getReceivedEmailSize());
 
 		// try it a second time (nervous user)
@@ -150,7 +150,7 @@ public class ResetPasswordTest extends JobsApiTestCase {
 		object = new JSONObject(resource.getResponseEntity().getText());
 		assertEquals(object.get("success"), true);
 
-		assertTrue(object.get("message").toString().contains("Email sent to"));
+		assertTrue(object.get("message").toString().contains("We sent you an email"));
 		assertEquals(mailsBefore + 2, mailServer.getReceivedEmailSize());
 
 		// check correct activtion code is in mail

--- a/src/test/java/cloudgene/mapred/api/v2/users/UserProfileTest.java
+++ b/src/test/java/cloudgene/mapred/api/v2/users/UserProfileTest.java
@@ -96,7 +96,7 @@ public class UserProfileTest extends JobsApiTestCase {
 		assertEquals(200, resource.getStatus().getCode());
 		JSONObject object = new JSONObject(resource.getResponseEntity().getText());
 		assertEquals(object.get("success"), true);
-		assertTrue(object.get("message").toString().contains("User profile sucessfully updated"));
+		assertTrue(object.get("message").toString().contains("User profile successfully updated"));
 		resource.release();
 
 		// try login with old password


### PR DESCRIPTION
By setting the property `emailRequired` to `false` in `settings.yaml`, this allows user registration without requiring an email. These users are initially added to the `anonymous_user` group. They can upgrade their user account by entering an email address on their profile page, after which they will be added to the `user` group.
