### PR TITLE
Reduce job status page refresh rate

### DIFF
--- a/src/main/html/webapp/components/core/job/detail/detail.js
+++ b/src/main/html/webapp/components/core/job/detail/detail.js
@@ -186,7 +186,7 @@ export default Control.extend({
       if (JobRefresher.needsUpdate(currentJob) && that.active) {
         setTimeout(function() {
           that.refresh();
-        }, 5000);
+        }, 20000);
       } else {
         // updates details (results, startTime, endTime, ...)
         JobDetails.findOne({

--- a/src/main/html/webapp/components/core/job/list/list.js
+++ b/src/main/html/webapp/components/core/job/list/list.js
@@ -135,7 +135,7 @@ var JobRefresher = Control({
       if (JobRefresher.needsUpdate(currentJob) && that.active) {
         setTimeout(function() {
           that.refresh();
-        }, 5000);
+        }, 20000);
       }
     }, function(response) {
       new ErrorPage(that.element, response);


### PR DESCRIPTION
## Purpose
The "job status" page provides feedback by refreshing every 5 sec.

When the queue is long, the server can experience loss of service quality just from status page checks _alone_. (see related [connection pool](https://github.com/genepi/cloudgene/issues/146) issue)

The new proposed value of 20 sec will reduce server load by ~75% for running job status checks, while still giving users frequent visible feedback during "fast" parts of the process like QC. 

Combined with other recent changes (DB indices, increased connection pool etc), this should be sufficient to prevent DoS when the site is used under normal conditions.

This will be included in our next fork release, and we're contributing it back for others.

## Related:
* https://github.com/genepi/cloudgene/issues/146
* https://github.com/lukfor/imputationbot/issues/33